### PR TITLE
XHR HttpClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@
 #### Setup
 
 ```sh
-npm install -g gulp
 npm install
 
-gulp watch
+./node_modules/.bin/gulp watch
 ```
 
 Load the app folder as unpacked extension. `gulp watch` watches for

--- a/app/src/lib/builder.js
+++ b/app/src/lib/builder.js
@@ -1,0 +1,395 @@
+'use strict';
+
+const capabilities = require('selenium-webdriver/lib/capabilities');
+const webdriver = require('selenium-webdriver/lib/webdriver');
+const http = require('./http');
+const chrome = require('./chrome');
+
+const Browser = capabilities.Browser;
+const Capabilities = capabilities.Capabilities;
+const Capability = capabilities.Capability;
+const WebDriver = webdriver.WebDriver;
+
+
+/**
+ * {@linkplain webdriver.WebDriver#setFileDetector WebDriver's setFileDetector}
+ * method uses a non-standard command to transfer files from the local client
+ * to the remote end hosting the browser. Many of the WebDriver sub-types, like
+ * the {@link chrome.Driver} and {@link firefox.Driver}, do not support this
+ * command. Thus, these classes override the `setFileDetector` to no-op.
+ *
+ * This function uses a mixin to re-enable `setFileDetector` by calling the
+ * original method on the WebDriver prototype directly. This is used only when
+ * the builder creates a Chrome or Firefox instance that communicates with a
+ * remote end (and thus, support for remote file detectors is unknown).
+ *
+ * @param {function(new: webdriver.WebDriver, ...?)} ctor
+ * @return {function(new: webdriver.WebDriver, ...?)}
+ */
+function ensureFileDetectorsAreEnabled(ctor) {
+  const mixin = class extends ctor {
+    /** @param {input.FileDetector} detector */
+    setFileDetector(detector) {
+      webdriver.WebDriver.prototype.setFileDetector.call(this, detector);
+    }
+  };
+  return mixin;
+}
+
+
+/**
+ * Creates new {@link webdriver.WebDriver WebDriver} instances.
+ */
+class Builder {
+  constructor() {
+    /** @private {promise.ControlFlow} */
+    this.flow_ = null;
+
+    /** @private {string} */
+    this.url_ = '';
+
+    /** @private {!Capabilities} */
+    this.capabilities_ = new Capabilities();
+
+    /** @private {chrome.Options} */
+    this.chromeOptions_ = null;
+
+    /** @private {firefox.Options} */
+    this.firefoxOptions_ = null;
+
+    /** @private {opera.Options} */
+    this.operaOptions_ = null;
+
+    /** @private {ie.Options} */
+    this.ieOptions_ = null;
+
+    /** @private {safari.Options} */
+    this.safariOptions_ = null;
+
+    /** @private {edge.Options} */
+    this.edgeOptions_ = null;
+  }
+
+  /**
+   * Sets the URL of a remote WebDriver server to use. Once a remote URL has
+   * been specified, the builder direct all new clients to that server. If this
+   * method is never called, the Builder will attempt to create all clients
+   * locally.
+   *
+   * As an alternative to this method, you may also set the
+   * `SELENIUM_REMOTE_URL` environment variable.
+   *
+   * @param {string} url The URL of a remote server to use.
+   * @return {!Builder} A self reference.
+   */
+  usingServer(url) {
+    this.url_ = url;
+    return this;
+  }
+
+  /**
+   * @return {string} The URL of the WebDriver server this instance is
+   *     configured to use.
+   */
+  getServerUrl() {
+    return this.url_;
+  }
+
+  /**
+   * Sets the desired capabilities when requesting a new session. This will
+   * overwrite any previously set capabilities.
+   * @param {!(Object|Capabilities)} capabilities The desired capabilities for
+   *     a new session.
+   * @return {!Builder} A self reference.
+   */
+  withCapabilities(capabilities) {
+    this.capabilities_ = new Capabilities(capabilities);
+    return this;
+  }
+
+  /**
+   * Returns the base set of capabilities this instance is currently configured
+   * to use.
+   * @return {!Capabilities} The current capabilities for this builder.
+   */
+  getCapabilities() {
+    return this.capabilities_;
+  }
+
+  /**
+   * Configures the target browser for clients created by this instance.
+   * Any calls to {@link #withCapabilities} after this function will
+   * overwrite these settings.
+   *
+   * You may also define the target browser using the {@code SELENIUM_BROWSER}
+   * environment variable. If set, this environment variable should be of the
+   * form `browser[:[version][:platform]]`.
+   *
+   * @param {(string|Browser)} name The name of the target browser;
+   *     common defaults are available on the {@link webdriver.Browser} enum.
+   * @param {string=} opt_version A desired version; may be omitted if any
+   *     version should be used.
+   * @param {string=} opt_platform The desired platform; may be omitted if any
+   *     version may be used.
+   * @return {!Builder} A self reference.
+   */
+  forBrowser(name, opt_version, opt_platform) {
+    this.capabilities_.set(Capability.BROWSER_NAME, name);
+    this.capabilities_.set(Capability.VERSION, opt_version || null);
+    this.capabilities_.set(Capability.PLATFORM, opt_platform || null);
+    return this;
+  }
+
+  /**
+   * Sets the proxy configuration for the target browser.
+   * Any calls to {@link #withCapabilities} after this function will
+   * overwrite these settings.
+   *
+   * @param {!capabilities.ProxyConfig} config The configuration to use.
+   * @return {!Builder} A self reference.
+   */
+  setProxy(config) {
+    this.capabilities_.setProxy(config);
+    return this;
+  }
+
+  /**
+   * Sets the logging preferences for the created session. Preferences may be
+   * changed by repeated calls, or by calling {@link #withCapabilities}.
+   * @param {!(./lib/logging.Preferences|Object<string, string>)} prefs The
+   *     desired logging preferences.
+   * @return {!Builder} A self reference.
+   */
+  setLoggingPrefs(prefs) {
+    this.capabilities_.setLoggingPrefs(prefs);
+    return this;
+  }
+
+  /**
+   * Sets whether native events should be used.
+   * @param {boolean} enabled Whether to enable native events.
+   * @return {!Builder} A self reference.
+   */
+  setEnableNativeEvents(enabled) {
+    this.capabilities_.setEnableNativeEvents(enabled);
+    return this;
+  }
+
+  /**
+   * Sets how elements should be scrolled into view for interaction.
+   * @param {number} behavior The desired scroll behavior: either 0 to align
+   *     with the top of the viewport or 1 to align with the bottom.
+   * @return {!Builder} A self reference.
+   */
+  setScrollBehavior(behavior) {
+    this.capabilities_.setScrollBehavior(behavior);
+    return this;
+  }
+
+  /**
+   * Sets the default action to take with an unexpected alert before returning
+   * an error.
+   * @param {string} behavior The desired behavior; should be "accept",
+   *     "dismiss", or "ignore". Defaults to "dismiss".
+   * @return {!Builder} A self reference.
+   */
+  setAlertBehavior(behavior) {
+    this.capabilities_.setAlertBehavior(behavior);
+    return this;
+  }
+
+  /**
+   * Sets Chrome specific {@linkplain chrome.Options options} for drivers
+   * created by this builder. Any logging or proxy settings defined on the given
+   * options will take precedence over those set through
+   * {@link #setLoggingPrefs} and {@link #setProxy}, respectively.
+   *
+   * @param {!chrome.Options} options The ChromeDriver options to use.
+   * @return {!Builder} A self reference.
+   */
+  setChromeOptions(options) {
+    this.chromeOptions_ = options;
+    return this;
+  }
+
+  /**
+   * Sets Firefox specific {@linkplain firefox.Options options} for drivers
+   * created by this builder. Any logging or proxy settings defined on the given
+   * options will take precedence over those set through
+   * {@link #setLoggingPrefs} and {@link #setProxy}, respectively.
+   *
+   * @param {!firefox.Options} options The FirefoxDriver options to use.
+   * @return {!Builder} A self reference.
+   */
+  setFirefoxOptions(options) {
+    this.firefoxOptions_ = options;
+    return this;
+  }
+
+  /**
+   * Sets Opera specific {@linkplain opera.Options options} for drivers created
+   * by this builder. Any logging or proxy settings defined on the given options
+   * will take precedence over those set through {@link #setLoggingPrefs} and
+   * {@link #setProxy}, respectively.
+   *
+   * @param {!opera.Options} options The OperaDriver options to use.
+   * @return {!Builder} A self reference.
+   */
+  setOperaOptions(options) {
+    this.operaOptions_ = options;
+    return this;
+  }
+
+  /**
+   * Set Internet Explorer specific {@linkplain ie.Options options} for drivers
+   * created by this builder. Any proxy settings defined on the given options
+   * will take precedence over those set through {@link #setProxy}.
+   *
+   * @param {!ie.Options} options The IEDriver options to use.
+   * @return {!Builder} A self reference.
+   */
+  setIeOptions(options) {
+    this.ieOptions_ = options;
+    return this;
+  }
+
+  /**
+   * Set {@linkplain edge.Options options} specific to Microsoft's Edge browser
+   * for drivers created by this builder. Any proxy settings defined on the
+   * given options will take precedence over those set through
+   * {@link #setProxy}.
+   *
+   * @param {!edge.Options} options The MicrosoftEdgeDriver options to use.
+   * @return {!Builder} A self reference.
+   */
+  setEdgeOptions(options) {
+    this.edgeOptions_ = options;
+    return this;
+  }
+
+  /**
+   * Sets Safari specific {@linkplain safari.Options options} for drivers
+   * created by this builder. Any logging settings defined on the given options
+   * will take precedence over those set through {@link #setLoggingPrefs}.
+   *
+   * @param {!safari.Options} options The Safari options to use.
+   * @return {!Builder} A self reference.
+   */
+  setSafariOptions(options) {
+    this.safariOptions_ = options;
+    return this;
+  }
+
+  /**
+   * Sets the control flow that created drivers should execute actions in. If
+   * the flow is never set, or is set to {@code null}, it will use the active
+   * flow at the time {@link #build()} is called.
+   * @param {promise.ControlFlow} flow The control flow to use, or
+   *     {@code null} to
+   * @return {!Builder} A self reference.
+   */
+  setControlFlow(flow) {
+    this.flow_ = flow;
+    return this;
+  }
+
+  /**
+   * Creates a new WebDriver client based on this builder's current
+   * configuration.
+   *
+   * While this method will immediately return a new WebDriver instance, any
+   * commands issued against it will be deferred until the associated browser
+   * has been fully initialized. Users may call {@link #buildAsync()} to obtain
+   * a promise that will not be fulfilled until the browser has been created
+   * (the difference is purely in style).
+   *
+   * @return {!webdriver.WebDriver} A new WebDriver instance.
+   * @throws {Error} If the current configuration is invalid.
+   * @see #buildAsync()
+   */
+  build() {
+    // Create a copy for any changes we may need to make based on the current
+    // environment.
+    let capabilities = new Capabilities(this.capabilities_),
+      browser = capabilities.get(Capability.BROWSER_NAME);
+
+    if (typeof browser !== 'string') {
+      throw TypeError(
+          `Target browser must be a string, but is <${typeof browser}>
+          ; did you forget to call forBrowser()?`);
+    }
+
+    if (browser === 'ie') {
+      browser = Browser.INTERNET_EXPLORER;
+    }
+
+    // Apply browser specific overrides.
+    if (browser === Browser.CHROME && this.chromeOptions_) {
+      capabilities.merge(this.chromeOptions_.toCapabilities());
+
+    } else if (browser === Browser.FIREFOX && this.firefoxOptions_) {
+      capabilities.merge(this.firefoxOptions_.toCapabilities());
+
+    } else if (browser === Browser.INTERNET_EXPLORER && this.ieOptions_) {
+      capabilities.merge(this.ieOptions_.toCapabilities());
+
+    } else if (browser === Browser.OPERA && this.operaOptions_) {
+      capabilities.merge(this.operaOptions_.toCapabilities());
+
+    } else if (browser === Browser.SAFARI && this.safariOptions_) {
+      capabilities.merge(this.safariOptions_.toCapabilities());
+
+    } else if (browser === Browser.EDGE && this.edgeOptions_) {
+      capabilities.merge(this.edgeOptions_.toCapabilities());
+    }
+
+    // Check for a remote browser.
+    if (this.url_) {
+      let client = Promise.resolve(this.url_)
+        .then(url => new http.Client(url));
+      let executor = new http.Executor(client);
+
+      if (browser === Browser.CHROME) {
+        const driver = ensureFileDetectorsAreEnabled(chrome.Driver);
+        return new driver(capabilities, executor, this.flow_);
+      }
+
+      if (browser === Browser.FIREFOX) {
+        const driver = ensureFileDetectorsAreEnabled(firefox.Driver);
+        return new driver(capabilities, executor, this.flow_);
+      }
+
+      return WebDriver.createSession(executor, capabilities, this.flow_);
+    }
+
+    // TODO: Use extension executor
+    if (browser === Browser.CHROME) {
+      throw new Error('Extension executor not implemented.');
+    } else {
+      throw new Error(
+        `Do not know how to build driver: ${browser}
+        ; did you forget to call usingServer(url)?`);
+    }
+  }
+
+  /**
+   * Creates a new WebDriver client based on this builder's current
+   * configuration. This method returns a promise that will not be fulfilled
+   * until the new browser session has been fully initialized.
+   *
+   * __Note:__ this method is purely a convenience wrapper around
+   * {@link #build()}.
+   *
+   * @return {!promise.Promise<!webdriver.WebDriver>} A promise that will be
+   *    fulfilled with the newly created WebDriver instance once the browser
+   *    has been fully initialized.
+   * @see #build()
+   */
+  buildAsync() {
+    let driver = this.build();
+    return driver.getSession().then(() => driver);
+  }
+}
+
+
+exports.Builder = Builder;

--- a/app/src/lib/chrome.js
+++ b/app/src/lib/chrome.js
@@ -1,0 +1,529 @@
+/**
+ * @fileoverview Defines configuration options for each new Chrome
+ *     session, such as which {@linkplain Options#setProxy proxy} to use,
+ *     what {@linkplain Options#addExtensions extensions} to install, or
+ *     what {@linkplain Options#addArguments command-line switches} to use when
+ *     starting the browser.
+ *
+ * __Starting the [ChromeDriver] Server__ <a id="custom-server"></a>
+ *
+ * You will need to start the ChromeDriver server manually if you wish to use the
+ * {@link http.HttpExecutor}.
+ *
+ * __Working with Android__ <a id="android"></a>
+ *
+ * The [ChromeDriver][android] supports running tests on the Chrome browser as
+ * well as [WebView apps][webview] starting in Android 4.4 (KitKat). In order to
+ * work with Android, you must first start the adb
+ *
+ *     adb start-server
+ *
+ * By default, adb will start on port 5037. You may change this port but this will
+ * require setting it through `--adb-port=` argument when starting ChromeDriver.
+ *
+ * The ChromeDriver may be configured to launch Chrome on Android using
+ * {@link Options#androidChrome()}:
+ *
+ *     let driver = new Builder()
+ *         .forBrowser('chrome')
+ *         .setChromeOptions(new chrome.Options().androidChrome())
+ *         .build();
+ *
+ * Alternatively, you can configure the ChromeDriver to launch an app with a
+ * Chrome-WebView by setting the {@linkplain Options#androidActivity
+ * androidActivity} option:
+ *
+ *     let driver = new Builder()
+ *         .forBrowser('chrome')
+ *         .setChromeOptions(new chrome.Options()
+ *             .androidPackage('com.example')
+ *             .androidActivity('com.example.Activity'))
+ *         .build();
+ *
+ * [Refer to the ChromeDriver site][ChromeDriver] for more information on using
+ * [ChromeDriver with Android][android].
+ *
+ * [ChromeDriver]: https://sites.google.com/a/chromium.org/chromedriver/
+ * [ChromeDriver release]: http://chromedriver.storage.googleapis.com/index.html
+ * [android]: https://sites.google.com/a/chromium.org/chromedriver/getting-started/getting-started---android
+ * [webview]: https://developer.chrome.com/multidevice/webview/overview
+ */
+
+'use strict';
+
+const capabilities = require('selenium-webdriver/lib/capabilities'),
+  Capabilities = capabilities.Capabilities,
+  Capability = capabilities.Capability,
+  Symbols = require('selenium-webdriver/lib/symbols'),
+  command = require('selenium-webdriver/lib/command'),
+  webdriver = require('selenium-webdriver/lib/webdriver'),
+  http = require('./http');
+
+
+/**
+ * @type {string}
+ * @const
+ */
+let OPTIONS_CAPABILITY_KEY = 'chromeOptions';
+
+
+/**
+ * Class for managing ChromeDriver specific options.
+ */
+class Options {
+  constructor() {
+    /** @private {!Object} */
+    this.options_ = {};
+
+    /** @private {!Array<(string|!Buffer)>} */
+    this.extensions_ = [];
+
+    /** @private {?logging.Preferences} */
+    this.logPrefs_ = null;
+
+    /** @private {?./lib/capabilities.ProxyConfig} */
+    this.proxy_ = null;
+  }
+
+  /**
+   * Extracts the ChromeDriver specific options from the given capabilities
+   * object.
+   * @param {!Capabilities} caps The capabilities object.
+   * @return {!Options} The ChromeDriver options.
+   */
+  static fromCapabilities(caps) {
+    let options = new Options();
+
+    let o = caps.get(OPTIONS_CAPABILITY_KEY);
+    if (o instanceof Options) {
+      options = o;
+    } else if (o) {
+      options.
+          addArguments(o.args || []).
+          addExtensions(o.extensions || []).
+          detachDriver(o.detach).
+          excludeSwitches(o.excludeSwitches || []).
+          setChromeBinaryPath(o.binary).
+          setChromeLogFile(o.logPath).
+          setChromeMinidumpPath(o.minidumpPath).
+          setLocalState(o.localState).
+          setMobileEmulation(o.mobileEmulation).
+          setUserPreferences(o.prefs).
+          setPerfLoggingPrefs(o.perfLoggingPrefs);
+    }
+
+    if (caps.has(Capability.PROXY)) {
+      options.setProxy(caps.get(Capability.PROXY));
+    }
+
+    if (caps.has(Capability.LOGGING_PREFS)) {
+      options.setLoggingPrefs(
+          caps.get(Capability.LOGGING_PREFS));
+    }
+
+    return options;
+  }
+
+  /**
+   * Add additional command line arguments to use when launching the Chrome
+   * browser.  Each argument may be specified with or without the "--" prefix
+   * (e.g. "--foo" and "foo"). Arguments with an associated value should be
+   * delimited by an "=": "foo=bar".
+   * @param {...(string|!Array<string>)} var_args The arguments to add.
+   * @return {!Options} A self reference.
+   */
+  addArguments(var_args) {
+    let args = this.options_.args || [];
+    args = args.concat.apply(args, arguments);
+    if (args.length) {
+      this.options_.args = args;
+    }
+    return this;
+  }
+
+  /**
+   * List of Chrome command line switches to exclude that ChromeDriver by default
+   * passes when starting Chrome.  Do not prefix switches with "--".
+   *
+   * @param {...(string|!Array<string>)} var_args The switches to exclude.
+   * @return {!Options} A self reference.
+   */
+  excludeSwitches(var_args) {
+    let switches = this.options_.excludeSwitches || [];
+    switches = switches.concat.apply(switches, arguments);
+    if (switches.length) {
+      this.options_.excludeSwitches = switches;
+    }
+    return this;
+  }
+
+  /**
+   * Add additional extensions to install when launching Chrome. Each extension
+   * should be specified as the path to the packed CRX file, or a Buffer for an
+   * extension.
+   * @param {...(string|!Buffer|!Array<(string|!Buffer)>)} var_args The
+   *     extensions to add.
+   * @return {!Options} A self reference.
+   */
+  addExtensions(var_args) {
+    this.extensions_ =
+        this.extensions_.concat.apply(this.extensions_, arguments);
+    return this;
+  }
+
+  /**
+   * Sets the path to the Chrome binary to use. On Mac OS X, this path should
+   * reference the actual Chrome executable, not just the application binary
+   * (e.g. "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome").
+   *
+   * The binary path be absolute or relative to the chromedriver server
+   * executable, but it must exist on the machine that will launch Chrome.
+   *
+   * @param {string} path The path to the Chrome binary to use.
+   * @return {!Options} A self reference.
+   */
+  setChromeBinaryPath(path) {
+    this.options_.binary = path;
+    return this;
+  }
+
+  /**
+   * Sets whether to leave the started Chrome browser running if the controlling
+   * ChromeDriver service is killed before {@link webdriver.WebDriver#quit()} is
+   * called.
+   * @param {boolean} detach Whether to leave the browser running if the
+   *     chromedriver service is killed before the session.
+   * @return {!Options} A self reference.
+   */
+  detachDriver(detach) {
+    this.options_.detach = detach;
+    return this;
+  }
+
+  /**
+   * Sets the user preferences for Chrome's user profile. See the "Preferences"
+   * file in Chrome's user data directory for examples.
+   * @param {!Object} prefs Dictionary of user preferences to use.
+   * @return {!Options} A self reference.
+   */
+  setUserPreferences(prefs) {
+    this.options_.prefs = prefs;
+    return this;
+  }
+
+  /**
+   * Sets the logging preferences for the new session.
+   * @param {!logging.Preferences} prefs The logging preferences.
+   * @return {!Options} A self reference.
+   */
+  setLoggingPrefs(prefs) {
+    this.logPrefs_ = prefs;
+    return this;
+  }
+
+  /**
+   * Sets the performance logging preferences. Options include:
+   *
+   * - `enableNetwork`: Whether or not to collect events from Network domain.
+   * - `enablePage`: Whether or not to collect events from Page domain.
+   * - `enableTimeline`: Whether or not to collect events from Timeline domain.
+   *     Note: when tracing is enabled, Timeline domain is implicitly disabled,
+   *     unless `enableTimeline` is explicitly set to true.
+   * - `tracingCategories`: A comma-separated string of Chrome tracing
+   *     categories for which trace events should be collected. An unspecified
+   *     or empty string disables tracing.
+   * - `bufferUsageReportingInterval`: The requested number of milliseconds
+   *     between DevTools trace buffer usage events. For example, if 1000, then
+   *     once per second, DevTools will report how full the trace buffer is. If
+   *     a report indicates the buffer usage is 100%, a warning will be issued.
+   *
+   * @param {{enableNetwork: boolean,
+   *          enablePage: boolean,
+   *          enableTimeline: boolean,
+   *          tracingCategories: string,
+   *          bufferUsageReportingInterval: number}} prefs The performance
+   *     logging preferences.
+   * @return {!Options} A self reference.
+   */
+  setPerfLoggingPrefs(prefs) {
+    this.options_.perfLoggingPrefs = prefs;
+    return this;
+  }
+
+  /**
+   * Sets preferences for the "Local State" file in Chrome's user data
+   * directory.
+   * @param {!Object} state Dictionary of local state preferences.
+   * @return {!Options} A self reference.
+   */
+  setLocalState(state) {
+    this.options_.localState = state;
+    return this;
+  }
+
+  /**
+   * Sets the name of the activity hosting a Chrome-based Android WebView. This
+   * option must be set to connect to an [Android WebView](
+   * https://sites.google.com/a/chromium.org/chromedriver/getting-started/getting-started---android)
+   *
+   * @param {string} name The activity name.
+   * @return {!Options} A self reference.
+   */
+  androidActivity(name) {
+    this.options_.androidActivity = name;
+    return this;
+  }
+
+  /**
+   * Sets the device serial number to connect to via ADB. If not specified, the
+   * ChromeDriver will select an unused device at random. An error will be
+   * returned if all devices already have active sessions.
+   *
+   * @param {string} serial The device serial number to connect to.
+   * @return {!Options} A self reference.
+   */
+  androidDeviceSerial(serial) {
+    this.options_.androidDeviceSerial = serial;
+    return this;
+  }
+
+  /**
+   * Configures the ChromeDriver to launch Chrome on Android via adb. This
+   * function is shorthand for
+   * {@link #androidPackage options.androidPackage('com.android.chrome')}.
+   * @return {!Options} A self reference.
+   */
+  androidChrome() {
+    return this.androidPackage('com.android.chrome');
+  }
+
+  /**
+   * Sets the package name of the Chrome or WebView app.
+   *
+   * @param {?string} pkg The package to connect to, or `null` to disable Android
+   *     and switch back to using desktop Chrome.
+   * @return {!Options} A self reference.
+   */
+  androidPackage(pkg) {
+    this.options_.androidPackage = pkg;
+    return this;
+  }
+
+  /**
+   * Sets the process name of the Activity hosting the WebView (as given by
+   * `ps`). If not specified, the process name is assumed to be the same as
+   * {@link #androidPackage}.
+   *
+   * @param {string} processName The main activity name.
+   * @return {!Options} A self reference.
+   */
+  androidProcess(processName) {
+    this.options_.androidProcess = processName;
+    return this;
+  }
+
+  /**
+   * Sets whether to connect to an already-running instead of the specified
+   * {@linkplain #androidProcess app} instead of launching the app with a clean
+   * data directory.
+   *
+   * @param {boolean} useRunning Whether to connect to a running instance.
+   * @return {!Options} A self reference.
+   */
+  androidUseRunningApp(useRunning) {
+    this.options_.androidUseRunningApp = useRunning;
+    return this;
+  }
+
+  /**
+   * Sets the path to Chrome's log file. This path should exist on the machine
+   * that will launch Chrome.
+   * @param {string} path Path to the log file to use.
+   * @return {!Options} A self reference.
+   */
+  setChromeLogFile(path) {
+    this.options_.logPath = path;
+    return this;
+  }
+
+  /**
+   * Sets the directory to store Chrome minidumps in. This option is only
+   * supported when ChromeDriver is running on Linux.
+   * @param {string} path The directory path.
+   * @return {!Options} A self reference.
+   */
+  setChromeMinidumpPath(path) {
+    this.options_.minidumpPath = path;
+    return this;
+  }
+
+  /**
+   * Configures Chrome to emulate a mobile device. For more information, refer
+   * to the ChromeDriver project page on [mobile emulation][em]. Configuration
+   * options include:
+   *
+   * - `deviceName`: The name of a pre-configured [emulated device][devem]
+   * - `width`: screen width, in pixels
+   * - `height`: screen height, in pixels
+   * - `pixelRatio`: screen pixel ratio
+   *
+   * __Example 1: Using a Pre-configured Device__
+   *
+   *     let options = new chrome.Options().setMobileEmulation(
+   *         {deviceName: 'Google Nexus 5'});
+   *
+   *     let driver = new chrome.Driver(options);
+   *
+   * __Example 2: Using Custom Screen Configuration__
+   *
+   *     let options = new chrome.Options().setMobileEmulation({
+   *         width: 360,
+   *         height: 640,
+   *         pixelRatio: 3.0
+   *     });
+   *
+   *     let driver = new chrome.Driver(options);
+   *
+   *
+   * [em]: https://sites.google.com/a/chromium.org/chromedriver/mobile-emulation
+   * [devem]: https://developer.chrome.com/devtools/docs/device-mode
+   *
+   * @param {?({deviceName: string}|
+   *           {width: number, height: number, pixelRatio: number})} config The
+   *     mobile emulation configuration, or `null` to disable emulation.
+   * @return {!Options} A self reference.
+   */
+  setMobileEmulation(config) {
+    this.options_.mobileEmulation = config;
+    return this;
+  }
+
+  /**
+   * Sets the proxy settings for the new session.
+   * @param {./lib/capabilities.ProxyConfig} proxy The proxy configuration to
+   *    use.
+   * @return {!Options} A self reference.
+   */
+  setProxy(proxy) {
+    this.proxy_ = proxy;
+    return this;
+  }
+
+  /**
+   * Converts this options instance to a {@link Capabilities} object.
+   * @param {Capabilities=} opt_capabilities The capabilities to merge
+   *     these options into, if any.
+   * @return {!Capabilities} The capabilities.
+   */
+  toCapabilities(opt_capabilities) {
+    let caps = opt_capabilities || Capabilities.chrome();
+    caps.
+        set(Capability.PROXY, this.proxy_).
+        set(Capability.LOGGING_PREFS, this.logPrefs_).
+        set(OPTIONS_CAPABILITY_KEY, this);
+    return caps;
+  }
+
+  /**
+   * Converts this instance to its JSON wire protocol representation. Note this
+   * function is an implementation not intended for general use.
+   * @return {!Object} The JSON wire protocol representation of this instance.
+   */
+  [Symbols.serialize]() {
+    let json = {};
+    for (let key in this.options_) {
+      if (this.options_[key] != null) {
+        json[key] = this.options_[key];
+      }
+    }
+    if (this.extensions_.length) {
+      json.extensions = this.extensions_.map(function(extension) {
+        if (Buffer.isBuffer(extension)) {
+          return extension.toString('base64');
+        }
+        // Reading extension files by path is not supported by this implementation.
+        console.warn(`Cannot install extension from path ${extension}.`);
+      });
+    }
+    return json;
+  }
+}
+
+
+/**
+ * Custom command names supported by ChromeDriver.
+ * @enum {string}
+ */
+const Command = {
+  LAUNCH_APP: 'launchApp'
+};
+
+
+/**
+ * Configures the given executor with Chrome-specific commands.
+ * @param {!http.Executor} executor the executor to configure.
+ */
+function configureExecutor(executor) {
+  executor.defineCommand(
+      Command.LAUNCH_APP,
+      'POST',
+      '/session/:sessionId/chromium/launch_app');
+}
+
+
+/**
+ * Creates a new WebDriver client for Chrome.
+ */
+class Driver extends webdriver.WebDriver {
+  /**
+   * @param {(Capabilities|Options)=} opt_config The configuration
+   *     options.
+   * @param {http.Executor} executor A pre-configured command executor that
+   *     should be used to send commands to the remote end. The provided
+   *     executor should not be reused with other clients as its internal
+   *     command mappings will be updated to support Chrome-specific commands.
+   * @param {promise.ControlFlow=} opt_flow The control flow to use,
+   *     or {@code null} to use the currently active flow.
+   */
+  constructor(opt_config, executor, opt_flow) {
+    if (executor instanceof http.Executor) {
+      configureExecutor(executor);
+    } else {
+      throw Error('Invalid executor.');
+    }
+
+    let caps =
+        opt_config instanceof Options ? opt_config.toCapabilities() :
+        (opt_config || Capabilities.chrome());
+
+    let driver = webdriver.WebDriver.createSession(executor, caps, opt_flow);
+
+    super(driver.getSession(), executor, driver.controlFlow());
+  }
+
+  /**
+   * This function is a no-op as file detectors are not supported by this
+   * implementation.
+   * @override
+   */
+  setFileDetector() {}
+
+  /**
+   * Schedules a command to launch Chrome App with given ID.
+   * @param {string} id ID of the App to launch.
+   * @return {!promise.Promise<void>} A promise that will be resolved
+   *     when app is launched.
+   */
+  launchApp(id) {
+    return this.schedule(
+        new command.Command(Command.LAUNCH_APP).setParameter('id', id),
+        'Driver.launchApp()');
+  }
+}
+
+
+// PUBLIC API
+
+
+exports.Driver = Driver;
+exports.Options = Options;

--- a/app/src/lib/http.js
+++ b/app/src/lib/http.js
@@ -1,113 +1,17 @@
-/**
- * Converts a headers object to a HTTP header block string.
- * @param {!Object.<string, string>} headers The headers object to convert.
- * @return {string} The headers as a string.
- * @private
- */
-function headersToString_(headers) {
-  var ret = [];
-  for (var key in headers) {
-    ret.push(key + ': ' + headers[key]);
-  }
-  return ret.join('\n');
-}
+'use strict';
 
+const http = require('selenium-webdriver/lib/http');
 
+// URLs regexp copied from angular.js, see:
+// https://github.com/angular/angular.js/blob/v1.5.0/src/ng/directive/input.js#L26
+const URL_REGEXP = /^[a-z][a-z\d.+-]*:\/*(?:[^:@]+(?::[^@]+)?@)?(?:[^\s:/?#]+|\[[a-f\d:]+\])(?::\d+)?(?:\/[^?#]*)?(?:\?[^#]*)?(?:#.*)?$/i;
 
 /**
- * Describes a partial HTTP request. This class is a "partial" request and only
- * defines the path on the server to send a request to. It is each
- * {@link webdriver.http.Client}'s responsibility to build the full URL for the
- * final request.
- * @param {!string} method The HTTP method to use for the request.
- * @param {!string} path Path on the server to send the request to.
- * @param {Object} opt_data This request's JSON data.
- * @constructor
- */
-function HttpRequest(method, path, opt_data) {
-
-  /**
-   * The HTTP method to use for the request.
-   * @type {!string}
-   */
-  this.method = method;
-
-  /**
-   * The path on the server to send the request to.
-   * @type {!string}
-   */
-  this.path = path;
-
-  /**
-   * This request's body.
-   * @type {Object}
-   */
-  this.data = opt_data;
-
-  /**
-   * The headers to send with the request.
-   * @type {!Object.<string, string>}
-   */
-  this.headers = {'Accept': 'application/json; charset=UTF-8'};
-}
-
-
-/** @override */
-HttpRequest.prototype.toString = function() {
-  var ret = [
-    `${this.method} ${this.path} HTTP/1.1`,
-    headersToString_(this.headers)
-  ];
-
-  if (this.data) {
-    ret.push('');
-    ret.push(JSON.stringify(this.data));
-  }
-
-  return ret.join('\n');
-};
-
-
-
-/**
- * Represents a HTTP response.
- * @param {!number} status The response code.
- * @param {!Object.<string>} headers The response headers. All header
- *     names will be converted to lowercase strings for consistent lookups.
- * @param {string} body The response body.
- * @constructor
- */
-function HttpResponse(status, headers, body) {
-
-  /**
-   * The HTTP response code.
-   * @type {!number}
-   */
-  this.status = status;
-
-  /**
-   * The response body.
-   * @type {string}
-   */
-  this.body = body;
-
-  /**
-   * The response headers.
-   * @type {!Object.<string, string>}
-   */
-  this.headers = {};
-  for (var header in headers) {
-    this.headers[header.toLowerCase()] = headers[header];
-  }
-}
-
-
-/**
- * Builds a {@link HttpResponse} from a {@link XMLHttpRequest} response object.
+ * Builds a {@link Response} from a {@link XMLHttpRequest} object.
  * @param {!XMLHttpRequest} xhr The request to parse.
- * @return {!HttpResponse} The parsed response.
+ * @return {!Response} The parsed response.
  */
-HttpResponse.fromXhr = function(xhr) {
+function fromXhr(xhr) {
   var headers = {};
 
   var tmp = xhr.getAllResponseHeaders();
@@ -121,38 +25,15 @@ HttpResponse.fromXhr = function(xhr) {
     });
   }
 
-  return new HttpResponse(xhr.status, headers, xhr.responseText.replace(/\0/g, ''));
-};
+  return new http.Response(xhr.status, headers, xhr.responseText.replace(/\0/g, ''));
+}
 
-
-/** @override */
-HttpResponse.prototype.toString = function() {
-  var headers = headersToString_(this.headers);
-  var ret = ['HTTP/1.1 ' + this.status, headers];
-
-  if (headers) {
-    ret.push('');
-  }
-
-  if (this.body) {
-    ret.push(this.body);
-  }
-
-  return ret.join('\n');
-};
-
-
-// TODO: require HttpRequest/HttpResponse from selenium-webdriver lib/http
-
-// URLs regexp copied from angular.js, see:
-// https://github.com/angular/angular.js/blob/v1.5.0/src/ng/directive/input.js#L26
-const URL_REGEXP = /^[a-z][a-z\d.+-]*:\/*(?:[^:@]+(?::[^@]+)?@)?(?:[^\s:/?#]+|\[[a-f\d:]+\])(?::\d+)?(?:\/[^?#]*)?(?:\?[^#]*)?(?:#.*)?$/i;
 
 /**
  * An XMLHttpRequest based HTTP client.
  *
  * @implements {http.Client}
- * @param {!string} serverUrl URL for the WebDriver server to send commands to.
+ * @param {string} serverUrl URL for the WebDriver server to send commands to.
  * @constructor
  */
 function HttpClient(serverUrl) {
@@ -171,9 +52,9 @@ function HttpClient(serverUrl) {
  * final response.
  *
  * @override
- * @param {!HttpRequest} request The request to send.
- * @return {!Promise<HttpResponse>} A promise that will be resolved with
- *   the server's response.
+ * @param {!Request} request The request to send.
+ * @return {!Promise<Response>} A promise that will be resolved with
+ *     the server's response.
  */
 HttpClient.prototype.send = function(request) {
   var url;
@@ -189,7 +70,7 @@ HttpClient.prototype.send = function(request) {
     xhr.open(request.method, url, true);
 
     xhr.onload = function() {
-      resolve(HttpResponse.fromXhr(xhr));
+      resolve(fromXhr(xhr));
     };
 
     xhr.onerror = function() {
@@ -202,9 +83,9 @@ HttpClient.prototype.send = function(request) {
       reject(new Error(message));
     };
 
-    for (var header in request.headers) {
-      xhr.setRequestHeader(header, request.headers[header] + '');
-    }
+    request.headers.forEach(function(value, name) {
+      xhr.setRequestHeader(name, value);
+    });
 
     if (request.method == 'POST' || request.method == 'PUT') {
       xhr.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
@@ -216,7 +97,9 @@ HttpClient.prototype.send = function(request) {
 
 
 module.exports = {
-  HttpRequest: HttpRequest,
-  HttpResponse: HttpResponse,
-  HttpClient: HttpClient
+  fromXhr: fromXhr,
+  Request: http.Request,
+  Response: http.Response,
+  Executor: http.Executor,
+  Client: HttpClient
 };

--- a/app/src/lib/http.js
+++ b/app/src/lib/http.js
@@ -87,11 +87,12 @@ HttpClient.prototype.send = function(request) {
       xhr.setRequestHeader(name, value);
     });
 
-    if (request.method == 'POST' || request.method == 'PUT') {
+    if (['POST', 'PUT'].indexOf(request.method) > -1) {
       xhr.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
+      xhr.send(JSON.stringify(request.data));
+    } else {
+      xhr.send();
     }
-
-    xhr.send(JSON.stringify(request.data));
   });
 };
 

--- a/app/src/lib/http.js
+++ b/app/src/lib/http.js
@@ -1,0 +1,222 @@
+/**
+ * Converts a headers object to a HTTP header block string.
+ * @param {!Object.<string, string>} headers The headers object to convert.
+ * @return {string} The headers as a string.
+ * @private
+ */
+function headersToString_(headers) {
+  var ret = [];
+  for (var key in headers) {
+    ret.push(key + ': ' + headers[key]);
+  }
+  return ret.join('\n');
+}
+
+
+
+/**
+ * Describes a partial HTTP request. This class is a "partial" request and only
+ * defines the path on the server to send a request to. It is each
+ * {@link webdriver.http.Client}'s responsibility to build the full URL for the
+ * final request.
+ * @param {!string} method The HTTP method to use for the request.
+ * @param {!string} path Path on the server to send the request to.
+ * @param {Object} opt_data This request's JSON data.
+ * @constructor
+ */
+function HttpRequest(method, path, opt_data) {
+
+  /**
+   * The HTTP method to use for the request.
+   * @type {!string}
+   */
+  this.method = method;
+
+  /**
+   * The path on the server to send the request to.
+   * @type {!string}
+   */
+  this.path = path;
+
+  /**
+   * This request's body.
+   * @type {Object}
+   */
+  this.data = opt_data;
+
+  /**
+   * The headers to send with the request.
+   * @type {!Object.<string, string>}
+   */
+  this.headers = {'Accept': 'application/json; charset=UTF-8'};
+}
+
+
+/** @override */
+HttpRequest.prototype.toString = function() {
+  var ret = [
+    `${this.method} ${this.path} HTTP/1.1`,
+    headersToString_(this.headers)
+  ];
+
+  if (this.data) {
+    ret.push('');
+    ret.push(JSON.stringify(this.data));
+  }
+
+  return ret.join('\n');
+};
+
+
+
+/**
+ * Represents a HTTP response.
+ * @param {!number} status The response code.
+ * @param {!Object.<string>} headers The response headers. All header
+ *     names will be converted to lowercase strings for consistent lookups.
+ * @param {string} body The response body.
+ * @constructor
+ */
+function HttpResponse(status, headers, body) {
+
+  /**
+   * The HTTP response code.
+   * @type {!number}
+   */
+  this.status = status;
+
+  /**
+   * The response body.
+   * @type {string}
+   */
+  this.body = body;
+
+  /**
+   * The response headers.
+   * @type {!Object.<string, string>}
+   */
+  this.headers = {};
+  for (var header in headers) {
+    this.headers[header.toLowerCase()] = headers[header];
+  }
+}
+
+
+/**
+ * Builds a {@link HttpResponse} from a {@link XMLHttpRequest} response object.
+ * @param {!XMLHttpRequest} xhr The request to parse.
+ * @return {!HttpResponse} The parsed response.
+ */
+HttpResponse.fromXhr = function(xhr) {
+  var headers = {};
+
+  var tmp = xhr.getAllResponseHeaders();
+  if (tmp) {
+    tmp = tmp.replace(/\r\n/g, '\n').split('\n');
+    tmp.forEach(function(header) {
+      var parts = header.split(/\s*:\s*/, 2);
+      if (parts[0]) {
+        headers[parts[0]] = parts[1] || '';
+      }
+    });
+  }
+
+  return new HttpResponse(xhr.status, headers, xhr.responseText.replace(/\0/g, ''));
+};
+
+
+/** @override */
+HttpResponse.prototype.toString = function() {
+  var headers = headersToString_(this.headers);
+  var ret = ['HTTP/1.1 ' + this.status, headers];
+
+  if (headers) {
+    ret.push('');
+  }
+
+  if (this.body) {
+    ret.push(this.body);
+  }
+
+  return ret.join('\n');
+};
+
+
+// TODO: require HttpRequest/HttpResponse from selenium-webdriver lib/http
+
+// URLs regexp copied from angular.js, see:
+// https://github.com/angular/angular.js/blob/v1.5.0/src/ng/directive/input.js#L26
+const URL_REGEXP = /^[a-z][a-z\d.+-]*:\/*(?:[^:@]+(?::[^@]+)?@)?(?:[^\s:/?#]+|\[[a-f\d:]+\])(?::\d+)?(?:\/[^?#]*)?(?:\?[^#]*)?(?:#.*)?$/i;
+
+/**
+ * An XMLHttpRequest based HTTP client.
+ *
+ * @implements {http.Client}
+ * @param {!string} serverUrl URL for the WebDriver server to send commands to.
+ * @constructor
+ */
+function HttpClient(serverUrl) {
+  if (!URL_REGEXP.test(serverUrl)) {
+    throw new Error(`Invalid server URL: ${serverUrl}`);
+  }
+
+  /** @private */
+  this.url_ = serverUrl;
+}
+
+
+/**
+ * Sends a request to the server. The client will automatically follow any
+ * redirects returned by the server, resolving the returned promise with the
+ * final response.
+ *
+ * @override
+ * @param {!HttpRequest} request The request to send.
+ * @return {!Promise<HttpResponse>} A promise that will be resolved with
+ *   the server's response.
+ */
+HttpClient.prototype.send = function(request) {
+  var url;
+
+  if (this.url_[this.url_.length - 1] === '/' && request.path[0] === '/') {
+    url = this.url_ + request.path.substring(1);
+  } else {
+    url = this.url_ + request.path;
+  }
+
+  return new Promise(function(resolve, reject) {
+    var xhr = new XMLHttpRequest();
+    xhr.open(request.method, url, true);
+
+    xhr.onload = function() {
+      resolve(HttpResponse.fromXhr(xhr));
+    };
+
+    xhr.onerror = function() {
+      var message = [
+        `Unable to send request: ${request.method} ${url}`,
+        'Original request:',
+        request
+      ].join('\n');
+
+      reject(new Error(message));
+    };
+
+    for (var header in request.headers) {
+      xhr.setRequestHeader(header, request.headers[header] + '');
+    }
+
+    if (request.method == 'POST' || request.method == 'PUT') {
+      xhr.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
+    }
+
+    xhr.send(JSON.stringify(request.data));
+  });
+};
+
+
+module.exports = {
+  HttpRequest: HttpRequest,
+  HttpResponse: HttpResponse,
+  HttpClient: HttpClient
+};

--- a/app/src/lib/index.js
+++ b/app/src/lib/index.js
@@ -1,3 +1,9 @@
+const by = require('selenium-webdriver/lib/by');
+const until = require('selenium-webdriver/lib/until');
 const version = require('./version');
+const builder = require('./builder');
 
+exports.Builder = builder.Builder;
+exports.By = by.By;
+exports.until = until;
 exports.version = version;

--- a/app/test/e2e.js
+++ b/app/test/e2e.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const webdriver = require('../src/lib/index'),
+  chrome = require('../src/lib/chrome'),
+  By = webdriver.By,
+  until = webdriver.until,
+  Builder = webdriver.Builder;
+
+if (process.browser) {
+  // only run in browser
+  run();
+}
+
+function run() {
+
+  // chrome specific options/capabilities
+  let chromeOptions = new chrome.Options()
+    .setMobileEmulation({deviceName: 'Google Nexus 5'});
+
+
+  let driver = new Builder()
+
+    .forBrowser('chrome')
+    .setChromeOptions(chromeOptions)
+
+    //.forBrowser('firefox')
+    //.forBrowser('safari')
+
+    // manually started webdriver servers
+    .usingServer('http://127.0.0.1:4444/wd/hub')
+    .usingServer('http://127.0.0.1:9515')
+
+    .build();
+
+
+  let message = [];
+  driver.call(message.push, message, 'a').then(function() {
+    driver.call(message.push, message, 'b');
+  });
+  driver.call(message.push, message, 'c');
+  driver.call(function() {
+    console.log('message is abc? ' + (message.join('') === 'abc'));
+  });
+
+
+  driver.get('http://www.google.com/ncr');
+  driver.findElement(By.name('q')).sendKeys('webdriver');
+  driver.findElement(By.name('btnG')).click();
+  driver.wait(until.titleIs('webdriver - Google Search'), 5000);
+  driver.quit();
+}

--- a/app/test/index.js
+++ b/app/test/index.js
@@ -5,5 +5,6 @@ const mocha = require('mocha');
 mocha.setup('bdd');
 
 require('./spec/version_spec.js');
+require('./spec/http_spec.js');
 
 mocha.run();

--- a/app/test/index.js
+++ b/app/test/index.js
@@ -1,10 +1,4 @@
 'use strict';
 
-const mocha = require('mocha');
-
-mocha.setup('bdd');
-
-require('./spec/version_spec.js');
-require('./spec/http_spec.js');
-
-mocha.run();
+require('./unit');
+require('./e2e');

--- a/app/test/spec/builder_spec.js
+++ b/app/test/spec/builder_spec.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const expect = require('chai').expect,
+  sinon = require('sinon'),
+  capabilities = require('selenium-webdriver/lib/capabilities'),
+  Builder = require('../../src/lib/builder').Builder;
+
+
+describe('Builder', function() {
+  let builder;
+
+
+  beforeEach(function() {
+    builder = new Builder();
+  });
+
+
+  describe('usingServer', function() {
+    it('sets server url', function() {
+      const serverUrl = 'http://webdriver.local';
+      builder.usingServer(serverUrl);
+
+      expect(builder.getServerUrl()).to.equal(serverUrl);
+    });
+  });
+
+
+  describe('withCapabilities', function() {
+    it('converts argument to `capabilities.Capabilities`', function() {
+      builder.withCapabilities({});
+      expect(builder.getCapabilities()).to.be.instanceof(capabilities.Capabilities);
+    });
+  });
+
+
+  describe('delegates capabilitis methods to the capabilities object', function() {
+    [
+      'setProxy',
+      'setLoggingPrefs',
+      'setEnableNativeEvents',
+      'setScrollBehavior',
+      'setAlertBehavior'
+    ].forEach(function(method) {
+
+      it(`${method}`, function() {
+        let spy = sinon.spy(builder.getCapabilities(), method);
+
+        builder[method]();
+        expect(spy.called).to.be.true;
+      });
+    });
+  });
+
+
+  describe('build', function() {
+
+    it('throws error if browser not set', function() {
+      expect(builder.build.bind(builder)).to.throw(/browser must be a string/i);
+    });
+
+    describe('when server url is not set', function() {
+
+      it('throws error for non-chrome browsers', function() {
+        builder.forBrowser(capabilities.Browser.FIREFOX);
+        expect(builder.build.bind(builder)).to.throw(/do not know how to build driver/i);
+      });
+
+      it('creates a `webdriver.WebDriver` instance with a `debugger.Executor` for chrome');
+    });
+  });
+
+});

--- a/app/test/spec/chrome_spec.js
+++ b/app/test/spec/chrome_spec.js
@@ -1,0 +1,193 @@
+'use strict';
+
+const expect = require('chai').expect,
+  proxy = require('selenium-webdriver/lib/proxy'),
+  symbols = require('selenium-webdriver/lib/symbols'),
+  capabilities = require('selenium-webdriver/lib/capabilities'),
+  Capabilities = capabilities.Capabilities,
+  Capability = capabilities.Capability,
+  chrome = require('../../src/lib/chrome'),
+  Options = chrome.Options;
+
+
+describe('chrome', function() {
+
+  it('exports Option', function() {
+    expect(chrome.Options).not.to.be.undefined;
+  });
+
+
+  describe('chrome.Options', function() {
+
+    describe('fromCapabilities', function() {
+      it('returns a new Options instance if none was defined', function() {
+        let options = Options.fromCapabilities(new Capabilities());
+        expect(options).to.be.instanceOf(Options);
+      });
+
+      it('returns Options instance if present', function() {
+        let options = new Options(),
+          caps = options.toCapabilities();
+        expect(caps).to.be.instanceOf(Capabilities);
+        expect(Options.fromCapabilities(caps)).to.equal(options);
+      });
+
+      it('rebuilds options from wire representation', function() {
+        const caps = Capabilities.chrome().set('chromeOptions', {
+          args: ['a', 'b'],
+          binary: 'binaryPath',
+          detach: true,
+          extensions: ['extensionFilePath'],
+          localState: 'localStateValue',
+          logPath: 'logFilePath',
+          prefs: 'prefsValue'
+        });
+
+        let options = Options.fromCapabilities(caps);
+
+        expect(options.extensions_.length).to.equal(1);
+        expect(options.extensions_[0]).to.equal('extensionFilePath');
+        expect(options.options_.args.length).to.equal(2);
+        expect(options.options_.args[0]).to.equal('a');
+        expect(options.options_.args[1]).to.equal('b');
+        expect(options.options_.binary).to.equal('binaryPath');
+        expect(options.options_.detach).to.equal(true);
+        expect(options.options_.localState).to.equal('localStateValue');
+        expect(options.options_.logPath).to.equal('logFilePath');
+        expect(options.options_.prefs).to.equal('prefsValue');
+      });
+
+      it('rebuilds options from incomplete wire representation', function() {
+        const caps = Capabilities.chrome().set('chromeOptions', {
+          logPath: 'logFilePath'
+        });
+
+        let options = Options.fromCapabilities(caps);
+
+        expect(options.extensions_.length).to.equal(0);
+        expect(options.options_.args).to.be.undefined;
+        expect(options.options_.binary).to.be.undefined;
+        expect(options.options_.detach).to.be.undefined;
+        expect(options.options_.excludeSwitches).to.be.undefined;
+        expect(options.options_.localState).to.be.undefined;
+        expect(options.options_.logPath).to.equal('logFilePath');
+        expect(options.options_.minidumpPath).to.be.undefined;
+        expect(options.options_.mobileEmulation).to.be.undefined;
+        expect(options.options_.perfLoggingPrefs).to.be.undefined;
+        expect(options.options_.prefs).to.be.undefined;
+      });
+
+      it('extracts supported WebDriver capabilities', function() {
+        const proxyPrefs = proxy.direct(),
+          logPrefs = {},
+          caps = Capabilities.chrome()
+            .set(Capability.PROXY, proxyPrefs)
+            .set(Capability.LOGGING_PREFS, logPrefs);
+
+        let options = Options.fromCapabilities(caps);
+
+        expect(options.proxy_).to.equal(proxyPrefs);
+        expect(options.logPrefs_).to.equal(logPrefs);
+      });
+    });
+
+
+    describe('addArguments', function() {
+      it('takes var_args', function() {
+        let options = new Options();
+        expect(options[symbols.serialize]().args).to.be.undefined;
+
+        options.addArguments('a', 'b');
+        let json = options[symbols.serialize]();
+        expect(json.args.length).to.equal(2);
+        expect(json.args[0]).to.equal('a');
+        expect(json.args[1]).to.equal('b');
+      });
+
+      it('flattens input arrays', function() {
+        let options = new Options();
+        expect(options[symbols.serialize]().args).to.be.undefined;
+
+        options.addArguments(['a', 'b'], 'c', [1, 2], 3);
+        let json = options[symbols.serialize]();
+        expect(json.args.length).to.equal(6);
+        expect(json.args[0]).to.equal('a');
+        expect(json.args[1]).to.equal('b');
+        expect(json.args[2]).to.equal('c');
+        expect(json.args[3]).to.equal(1);
+        expect(json.args[4]).to.equal(2);
+        expect(json.args[5]).to.equal(3);
+      });
+    });
+
+
+    describe('addExtensions', function() {
+      it('takes var_args', function() {
+        let options = new Options();
+        expect(options.extensions_.length).to.equal(0);
+
+        options.addExtensions('a', 'b');
+        expect(options.extensions_.length).to.equal(2);
+        expect(options.extensions_[0]).to.equal('a');
+        expect(options.extensions_[1]).to.equal('b');
+      });
+
+      it('flattens input arrays', function() {
+        let options = new Options();
+        expect(options.extensions_.length).to.equal(0);
+
+        options.addExtensions(['a', 'b'], 'c', [1, 2], 3);
+        expect(options.extensions_.length).to.equal(6);
+        expect(options.extensions_[0]).to.equal('a');
+        expect(options.extensions_[1]).to.equal('b');
+        expect(options.extensions_[2]).to.equal('c');
+        expect(options.extensions_[3]).to.equal(1);
+        expect(options.extensions_[4]).to.equal(2);
+        expect(options.extensions_[5]).to.equal(3);
+      });
+    });
+
+
+    describe('serialize', function() {
+      it('does not support base64 encodes extensions', function() {
+        var json = new Options().addExtensions('extensionFilePath')[symbols.serialize]();
+        expect(json.extensions.length).to.equal(1);
+        expect(json.extensions[0]).to.be.undefined;
+      });
+    });
+
+
+    describe('toCapabilities', function() {
+      it('returns a new capabilities object if one is not provided', function() {
+        let options = new Options(),
+          caps = options.toCapabilities();
+
+        expect(caps.get('browserName')).to.equal('chrome');
+        expect(caps.get('chromeOptions')).to.equal(options);
+      });
+
+      it('adds to input capabilities object', function() {
+        let caps = Capabilities.firefox(),
+          options = new chrome.Options();
+
+        expect(options.toCapabilities(caps)).to.equal(caps);
+        expect(caps.get('browserName')).to.equal('firefox');
+        expect(caps.get('chromeOptions')).to.equal(options);
+      });
+
+      it('sets generic driver capabilities', function() {
+        let proxyPrefs = {},
+          loggingPrefs = {},
+          options = new chrome.Options()
+            .setLoggingPrefs(loggingPrefs)
+            .setProxy(proxyPrefs),
+          caps = options.toCapabilities();
+
+        expect(caps.get('proxy')).to.equal(proxyPrefs);
+        expect(caps.get('loggingPrefs')).to.equal(loggingPrefs);
+      });
+    });
+
+  });
+
+});

--- a/app/test/spec/chrome_spec.js
+++ b/app/test/spec/chrome_spec.js
@@ -59,7 +59,8 @@ describe('chrome', function() {
 
       it('rebuilds options from incomplete wire representation', function() {
         const caps = Capabilities.chrome().set('chromeOptions', {
-          logPath: 'logFilePath'
+          logPath: 'logFilePath',
+          excludeSwitches: ['allow-running-insecure-content']
         });
 
         let options = Options.fromCapabilities(caps);
@@ -68,7 +69,7 @@ describe('chrome', function() {
         expect(options.options_.args).to.be.undefined;
         expect(options.options_.binary).to.be.undefined;
         expect(options.options_.detach).to.be.undefined;
-        expect(options.options_.excludeSwitches).to.be.undefined;
+        expect(options.options_.excludeSwitches).to.contain('allow-running-insecure-content');
         expect(options.options_.localState).to.be.undefined;
         expect(options.options_.logPath).to.equal('logFilePath');
         expect(options.options_.minidumpPath).to.be.undefined;

--- a/app/test/spec/http_spec.js
+++ b/app/test/spec/http_spec.js
@@ -140,8 +140,16 @@ describe('http', function() {
 
       ['POST', 'PUT'].forEach(function(method) {
         it(`sets "Content-Type" header to json for ${method}`, function() {
-          httpClient.send(new Request(method, '/path'));
+          httpClient.send(new Request(method, '/path', {}));
           expect(xhrq[0].requestHeaders['Content-Type']).to.match(/json/i);
+          expect(xhrq[0].requestBody).to.equal(JSON.stringify({}));
+        });
+      });
+
+      ['GET', 'PATCH', 'DELETE'].forEach(function(method) {
+        it(`does not send request body for ${method}`, function() {
+          httpClient.send(new Request(method, '/path', {}));
+          expect(xhrq[0].requestBody).to.oneOf([null, undefined]);
         });
       });
 

--- a/app/test/spec/http_spec.js
+++ b/app/test/spec/http_spec.js
@@ -1,0 +1,138 @@
+var expect = require('chai').expect,
+  sinon =  require('sinon'),
+  http = require('../../scripts/lib/http'),
+  HttpRequest = http.HttpRequest,
+  HttpResponse = http.HttpResponse,
+  HttpClient = http.HttpClient;
+
+describe('HttpRequest', function() {
+  var request, METHOD = 'GET', PATH = '/path';
+
+  beforeEach(function() {
+    request = new HttpRequest(METHOD, PATH);
+  });
+
+  it('sets method', function() {
+    expect(request.method).to.equal(METHOD);
+  });
+
+  it('sets path', function() {
+    expect(request.path).to.equal(PATH);
+  });
+});
+
+describe('HttpResponse', function() {
+
+  describe('fromXhr', function() {
+    var mockXhr;
+
+    beforeEach(function() {
+      mockXhr = {
+        status: 200,
+        responseText: '',
+        getAllResponseHeaders: sinon.spy()
+      };
+    });
+
+    it('sets status', function() {
+      var response = HttpResponse.fromXhr(mockXhr);
+      expect(response.status).to.equal(mockXhr.status);
+    });
+
+    it('strips null characters from response body', function() {
+      mockXhr.responseText = '\x00foo\x00\x00bar\x00';
+
+      var response = HttpResponse.fromXhr(mockXhr);
+      expect(response.body).to.equal('foobar');
+    });
+
+    describe('parses headers', function() {
+      var headers, parsedHeaders;
+
+      beforeEach(function() {
+        headers = [
+          'a:b',
+          'c: d',
+          'e :f',
+          'g : h'
+        ];
+        parsedHeaders = {
+          'a': 'b',
+          'c': 'd',
+          'e': 'f',
+          'g': 'h'
+        };
+      });
+      it('windows', function() {
+        mockXhr.getAllResponseHeaders = sinon.stub().returns(headers.join('\r\n'));
+
+        var response = HttpResponse.fromXhr(mockXhr);
+        expect(response.headers).to.eql(parsedHeaders);
+      });
+
+      it('unix', function() {
+        mockXhr.getAllResponseHeaders = sinon.stub().returns(headers.join('\n'));
+
+        var response = HttpResponse.fromXhr(mockXhr);
+        expect(response.headers).to.eql(parsedHeaders);
+      });
+
+      it('handles response with no headers', function() {
+        mockXhr.getAllResponseHeaders = sinon.stub().returns('');
+
+        var response = HttpResponse.fromXhr(mockXhr);
+        expect(response.headers).to.eql({});
+      });
+    });
+  });
+});
+
+describe('HttpClient', function() {
+  var FakeXhr, requests, httpClient;
+
+  before(function() {
+    FakeXhr = sinon.useFakeXMLHttpRequest();
+    global.XMLHttpRequest = FakeXhr;
+
+    requests = [];
+    FakeXhr.onCreate = function(xhr) {
+      requests.push(xhr);
+    };
+  });
+
+  after(function() {
+    FakeXhr.restore();
+    global.XMLHttpRequest = undefined;
+  });
+
+  beforeEach(function() {
+    requests.length = 0;
+
+    httpClient = new HttpClient('http://webdriver.local');
+  });
+
+  describe('constructor', function() {
+    it('throws error if serverUrl is invalid', function() {
+      expect(function() {
+        new HttpClient('invalid.url');
+      }).to.throw(/invalid server url/i);
+    });
+  });
+
+  describe('#send()', function() {
+
+    it('returns promise resolving the response', function(done) {
+      httpClient.send(new HttpRequest())
+      .then(function(res) {
+        expect(res).to.be.instanceOf(HttpResponse);
+        expect(res.body).to.equal('OK');
+
+        done();
+      });
+
+      requests[0].respond(200, {}, 'OK');
+    });
+
+    it('rejects with an error if somethings wrong');
+  });
+});

--- a/app/test/spec/index_spec.js
+++ b/app/test/spec/index_spec.js
@@ -1,0 +1,10 @@
+var expect = require('chai').expect,
+  index = require('../../src/lib/index');
+
+describe('index', function() {
+  ['version', 'Builder', 'By', 'until'].forEach(function(func) {
+    it(`exports ${func}`, function() {
+      expect(index[func]).not.to.be.undefined;
+    });
+  });
+});

--- a/app/test/unit.js
+++ b/app/test/unit.js
@@ -4,9 +4,10 @@ const mocha = require('mocha');
 
 mocha.setup('bdd');
 
-require('./spec/version_spec.js');
-require('./spec/http_spec.js');
+require('./spec/builder_spec.js');
 require('./spec/chrome_spec.js');
+require('./spec/http_spec.js');
 require('./spec/index_spec.js');
+require('./spec/version_spec.js');
 
 mocha.run();

--- a/app/test/unit.js
+++ b/app/test/unit.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const mocha = require('mocha');
+
+mocha.setup('bdd');
+
+require('./spec/version_spec.js');
+require('./spec/http_spec.js');
+require('./spec/chrome_spec.js');
+require('./spec/index_spec.js');
+
+mocha.run();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -73,6 +73,7 @@ gulp.task('extras', () => {
     'app/images/**',
     'app/bundles/*',
     'app/test/*',
+    '!app/node_modules',
     '!app/*.json'
   ], {
     base: 'app',

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "istanbul": "^0.4.3",
     "jsdoc": "^3.4.0",
     "json-loader": "^0.5.4",
-    "mocha": "^2.5.3",
+    "mocha": "^3.0.2",
     "run-sequence": "^1.1.5",
     "sinon": "^1.17.5",
     "webpack": "^1.13.1"

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "json-loader": "^0.5.4",
     "mocha": "^2.5.3",
     "run-sequence": "^1.1.5",
-    "sinon": "^1.17.4",
+    "sinon": "^1.17.5",
     "webpack": "^1.13.1"
   },
   "dependencies": {
-    "selenium-webdriver": "^2.53.2",
+    "selenium-webdriver": "3.0.0-beta-2",
     "semver": "^5.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "json-loader": "^0.5.4",
     "mocha": "^3.0.2",
     "run-sequence": "^1.1.5",
-    "sinon": "^1.17.5",
+    "sinon": "2.0.0-pre.2",
     "webpack": "^1.13.1"
   },
   "dependencies": {


### PR DESCRIPTION
Add an XHR based HTTP client that implements `selenium-webdriver` `http.Client` interface.

This makes `selenium-webdriver` working in a chrome extension.

`builder.js`, `chrome.js` are based on relavent files from [selenium-webdriver 3.0.0-beta-2](https://github.com/SeleniumHQ/selenium/tree/62f83f52873083dd5c484a158dfcafa3d114ec4a/javascript/node/selenium-webdriver)
#### `builder.js`
- Remove reading environment variables.
- Remove webdriver client proxy setting.
- Remove webdriver client user agent setting. Use the extension's [`webRequest`](http://stackoverflow.com/a/21092748/1528046) API to change user agent potentially.
- Remove managing webdriver servers processes. Webdriver servers must be manually started in order to use the http executor.
- Only support chrome specific options at this stage.
#### `chrome.js`
- Remove managing ChromeDriver server processes.
- Drop extensions support.
